### PR TITLE
Fix author "Anonymous"

### DIFF
--- a/plugins/rss.lua
+++ b/plugins/rss.lua
@@ -194,7 +194,7 @@ function plugin.min_cron()
       local text = ''  -- Send only one message with all updates
       for k2, v2 in pairs(newentr) do
          local title = v2.title or 'No title'
-         local author = v2.creator or 'Anonymous'
+         local author = v2.author or 'Anonymous'
          local link = v2.link or v2.id or 'No Link'
          if v2.summary or v2.description or v2.content then
           summary_text = v2.summary or v2.description or v2.content


### PR DESCRIPTION
I was looking at the [Lua Feedparser](https://github.com/slact/lua-feedparser) and there was no "creator" in the sample table instead there was "author". So I thought this might fix the author name always being displayed as Anonymous